### PR TITLE
Import default property to support raw-loader default configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Webpack loader that inlines all html for AngularJS code that specifies a `templa
 - [How does it work](#how-does-it-work)
 - [Common Issues](#common-issues)
 
+### This Fork
+Since we are using raw-loader, it returns an object with the default properties to be compatible with ES6 standard. This tool uses ES5 syntax so we need to access to default value explicitly. Another possible solution is to upgrade raw-loader to 4.0.0 and use `esModules: false` properties but our build tool chain uses a node version not supported by raw-loader 4.x.
+
 ### Installation
 Option 1: Install from [npm](https://www.npmjs.com/package/angularjs-template-loader).
 - `npm install angularjs-template-loader --save-dev`
@@ -71,7 +74,7 @@ angular.module("my-module").component("my-component", {
 #### After (before it is bundled into your webpack'd application)
 ```js
 angular.module("my-module").component("my-component", {
-  template: require('/root/some/path/app/src/myComponent.html" ,
+  template: require('/root/some/path/app/src/myComponent.html").default,
   controller: "MyController"
 });
 ```

--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ Webpack loader that inlines all html for AngularJS code that specifies a `templa
 - [How does it work](#how-does-it-work)
 - [Common Issues](#common-issues)
 
-### This Fork
-Since we are using raw-loader, it returns an object with the default properties to be compatible with ES6 standard. This tool uses ES5 syntax so we need to access to default value explicitly. Another possible solution is to upgrade raw-loader to 4.0.0 and use `esModules: false` properties but our build tool chain uses a node version not supported by raw-loader 4.x.
-
 ### Installation
 Option 1: Install from [npm](https://www.npmjs.com/package/angularjs-template-loader).
 - `npm install angularjs-template-loader --save-dev`

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function replaceStringsWithRequires(string, relativeTo) {
       url = "./" + url;
     }
     if (os.platform() === "win32") url = url.replace(/\\/g, '\\\\');
-    return "require('" + url + "')";
+    return "require('" + url + "').default";
   });
 }
 


### PR DESCRIPTION
Since we are using raw-loader to load HTML file, it returns an object with the default properties to be compatible with ES6 standard. This tool uses ES5 syntax ( required(..) ) so we need to access to default value explicitly.

Another possible solution, instead of these changes, is to upgrade raw-loader to 4.0.0 and use `esModules: false` properties but this introduces two different problems:
 - our build toolchain uses a node version not supported by raw-loader 4.x (it required node >= 10.13)
 - you your toolchain uses raw-loader to manage other types of import, forcing it to use `esModules:false` can be  too much restrictive